### PR TITLE
get a prod package (#112)

### DIFF
--- a/.github/workflows/delete.packages.yml
+++ b/.github/workflows/delete.packages.yml
@@ -20,8 +20,8 @@ jobs:
     steps:
     - name: Delete packages
       id: deletePackages
-      uses: actions/delete-package-versions@v3
+      uses: actions/delete-package-versions@v4
       with:
         package-name: '${{github.event.inputs.name}}'
+        package-type: 'nuget'
         num-old-versions-to-delete: ${{github.event.inputs.num-old-versions-to-delete}}
-          

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2022 Trakx
+Copyright (c) 2023 Trakx
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/src/Common.Projects.props
+++ b/src/Common.Projects.props
@@ -1,7 +1,7 @@
 <Project>
     <PropertyGroup>
         <Company>Trakx</Company>
-        <Copyright>Copyright © 2022 Trakx</Copyright>
+        <Copyright>Copyright © 2023 Trakx</Copyright>
         <RepositoryUrl>https://github.com/trakx/shrimpy-api-client</RepositoryUrl>
         <RepositoryType>git</RepositoryType>
         <Deterministic>true</Deterministic>

--- a/src/Trakx.Shrimpy.ApiClient.Tests/Trakx.Shrimpy.ApiClient.Tests.csproj
+++ b/src/Trakx.Shrimpy.ApiClient.Tests/Trakx.Shrimpy.ApiClient.Tests.csproj
@@ -8,7 +8,7 @@
   <Import Project="../Common.Projects.props" />
 
   <ItemGroup>
-    <PackageReference Include="coverlet.msbuild" Version="3.1.2">
+    <PackageReference Include="coverlet.msbuild" Version="3.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -27,7 +27,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.2">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/Trakx.Shrimpy.ApiClient/ApiClients.cs
+++ b/src/Trakx.Shrimpy.ApiClient/ApiClients.cs
@@ -682,20 +682,20 @@ namespace Trakx.Shrimpy.ApiClient
         [System.Runtime.Serialization.EnumMember(Value = @"binanceUs")]
         BinanceUs = 1,
 
-        [System.Runtime.Serialization.EnumMember(Value = @"ftx")]
-        Ftx = 2,
-
-        [System.Runtime.Serialization.EnumMember(Value = @"ftxUs")]
-        FtxUs = 3,
+        [System.Runtime.Serialization.EnumMember(Value = @"bittrex")]
+        Bittrex = 2,
 
         [System.Runtime.Serialization.EnumMember(Value = @"coinbasePro")]
-        CoinbasePro = 4,
+        CoinbasePro = 3,
 
         [System.Runtime.Serialization.EnumMember(Value = @"kraken")]
-        Kraken = 5,
+        Kraken = 4,
 
         [System.Runtime.Serialization.EnumMember(Value = @"kucoin")]
-        Kucoin = 6,
+        Kucoin = 5,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"poloniex")]
+        Poloniex = 6,
 
         [System.Runtime.Serialization.EnumMember(Value = @"huobiGlobal")]
         HuobiGlobal = 7,
@@ -706,9 +706,20 @@ namespace Trakx.Shrimpy.ApiClient
         [System.Runtime.Serialization.EnumMember(Value = @"gemini")]
         Gemini = 9,
 
-        [System.Runtime.Serialization.EnumMember(Value = @"gateIo")]
-        GateIo = 10,
+        [System.Runtime.Serialization.EnumMember(Value = @"bibox")]
+        Bibox = 10,
 
+        [System.Runtime.Serialization.EnumMember(Value = @"hitBtc")]
+        HitBtc = 11,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"bitmart")]
+        Bitmart = 12,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"bitstamp")]
+        Bitstamp = 13,
+
+        [System.Runtime.Serialization.EnumMember(Value = @"bitfinex")]
+        Bitfinex = 14,
     }
 
     /// <summary>

--- a/src/Trakx.Shrimpy.ApiClient/FavouriteExchangesClient.cs
+++ b/src/Trakx.Shrimpy.ApiClient/FavouriteExchangesClient.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using Trakx.Utils.Extensions;
 
 namespace Trakx.Shrimpy.ApiClient;
 
@@ -10,12 +11,13 @@ public abstract class FavouriteExchangesClient : IFavouriteExchangesClient
     protected FavouriteExchangesClient(ClientConfigurator clientConfigurator)
     {
         ApiConfiguration = clientConfigurator.ApiConfiguration;
-        Top12ExchangeIds = ApiConfiguration.FavouriteExchanges?.Count > 0
-            ? ApiConfiguration.FavouriteExchanges!.AsReadOnly()
-            : new List<string>
+
+        Top12ExchangeIds = string.IsNullOrWhiteSpace(ApiConfiguration.FavouriteExchangesAsCsv)
+            ? new List<string>
             {
-                "binance", "binanceUs", "ftx", "ftxus", "coinbasePro", "kraken", "kucoin", "huobiGlobal", "okex", "gemini", "gateio"
-            }.AsReadOnly();
+                "binance", "binanceUs", "coinbasePro", "kraken", "kucoin", "huobiGlobal", "gemini", "gateio", "bittrex"
+            }.AsReadOnly()
+            : ApiConfiguration.FavouriteExchangesAsCsv.SplitCsvToLowerCaseDistinctList();
 
         Top12ExchangeIdsAsCsv = string.Join(",", Top12ExchangeIds);
     }

--- a/src/Trakx.Shrimpy.ApiClient/ShrimpyApiConfiguration.cs
+++ b/src/Trakx.Shrimpy.ApiClient/ShrimpyApiConfiguration.cs
@@ -15,6 +15,8 @@ public record ShrimpyApiConfiguration
     [AwsParameter]
     [SecretEnvironmentVariable]
     public string ApiSecret { get; init; }
-    public List<string> FavouriteExchanges { get; init; }
+
+    [AwsParameter]
+    public string FavouriteExchangesAsCsv { get; init; }
 #nullable restore
 }

--- a/src/Trakx.Shrimpy.ApiClient/openApi3.yaml
+++ b/src/Trakx.Shrimpy.ApiClient/openApi3.yaml
@@ -134,8 +134,7 @@ components:
             $ref: "#/components/schemas/ExchangeApiError"
     Exchange:
       type: string
-      #enum: [ binance, binanceUs, bittrex, coinbasePro, kraken, kucoin, poloniex, huobiGlobal, okex, gemini, bibox, hitBtc, bitmart, bitstamp, bitfinex ]
-      enum: [ binance, binanceUs, ftx, ftxUs, coinbasePro, kraken, kucoin, huobiGlobal, okex, gemini, gateIo ]
+      enum: [ binance, binanceUs, bittrex, coinbasePro, kraken, kucoin, poloniex, huobiGlobal, okex, gemini, bibox, hitBtc, bitmart, bitstamp, bitfinex ]
       description: A unique identifier for the exchange that is used with other Shrimpy endpoints. This is typically the lowercase name of the exchange without spaces.
       example: kucoin
     ExchangeApiError:


### PR DESCRIPTION
* Upgrade packages and get Ci/Cd secrets from AWS (#37)

* Upgrade packages and get Ci/Cd secrets from AWS

* upgrade libraries and actions

* update README.md

* update README.md

* don't publish if build failed

* only publish on successful build

* only publish nuget from success test suite

* chore(deps): bump Trakx.Utils.Testing from 0.3.13 to 0.6.7 (#59)

Bumps Trakx.Utils.Testing from 0.3.13 to 0.6.7.

---
updated-dependencies:
- dependency-name: Trakx.Utils.Testing dependency-type: direct:production update-type: version-update:semver-minor ...





* chore(deps): bump Microsoft.Extensions.Http.Polly from 6.0.4 to 6.0.6 (#50)

Bumps [Microsoft.Extensions.Http.Polly](https://github.com/dotnet/aspnetcore) from 6.0.4 to 6.0.6.
- [Release notes](https://github.com/dotnet/aspnetcore/releases)
- [Changelog](https://github.com/dotnet/aspnetcore/blob/main/docs/ReleasePlanning.md)
- [Commits](https://github.com/dotnet/aspnetcore/compare/v6.0.4...v6.0.6)

---
updated-dependencies:
- dependency-name: Microsoft.Extensions.Http.Polly dependency-type: direct:production update-type: version-update:semver-patch ...





* chore(deps): bump Trakx.Utils from 0.3.14 to 0.6.7 (#58)

Bumps Trakx.Utils from 0.3.14 to 0.6.7.

---
updated-dependencies:
- dependency-name: Trakx.Utils dependency-type: direct:production update-type: version-update:semver-minor ...





* chore(deps): bump GitHubActionsTestLogger from 2.0.0 to 2.0.1 (#60)

Bumps [GitHubActionsTestLogger](https://github.com/Tyrrrz/GitHubActionsTestLogger) from 2.0.0 to 2.0.1.
- [Release notes](https://github.com/Tyrrrz/GitHubActionsTestLogger/releases)
- [Changelog](https://github.com/Tyrrrz/GitHubActionsTestLogger/blob/master/Changelog.md)
- [Commits](https://github.com/Tyrrrz/GitHubActionsTestLogger/compare/2.0...2.0.1)

---
updated-dependencies:
- dependency-name: GitHubActionsTestLogger dependency-type: direct:production update-type: version-update:semver-patch ...





* chore(deps): bump NSwag.MSBuild from 13.16.0 to 13.16.1 (#61)

Bumps [NSwag.MSBuild](https://github.com/RicoSuter/NSwag) from 13.16.0 to 13.16.1.
- [Release notes](https://github.com/RicoSuter/NSwag/releases)
- [Changelog](https://github.com/RicoSuter/NSwag/blob/master/CHANGELOG.md)
- [Commits](https://github.com/RicoSuter/NSwag/compare/v13.16.0...v13.16.1)

---
updated-dependencies:
- dependency-name: NSwag.MSBuild dependency-type: direct:production update-type: version-update:semver-patch ...





* chore(deps): bump Microsoft.AspNetCore.Mvc.NewtonsoftJson (#51)

Bumps [Microsoft.AspNetCore.Mvc.NewtonsoftJson](https://github.com/dotnet/aspnetcore) from 6.0.4 to 6.0.6.
- [Release notes](https://github.com/dotnet/aspnetcore/releases)
- [Changelog](https://github.com/dotnet/aspnetcore/blob/main/docs/ReleasePlanning.md)
- [Commits](https://github.com/dotnet/aspnetcore/compare/v6.0.4...v6.0.6)

---
updated-dependencies:
- dependency-name: Microsoft.AspNetCore.Mvc.NewtonsoftJson dependency-type: direct:production update-type: version-update:semver-patch ...





* chore(deps): bump Trakx.Utils.Testing from 0.6.7 to 0.6.9 (#62)

Bumps Trakx.Utils.Testing from 0.6.7 to 0.6.9.

---
updated-dependencies:
- dependency-name: Trakx.Utils.Testing dependency-type: direct:production update-type: version-update:semver-patch ...





* chore(deps): bump Microsoft.AspNetCore.Mvc.NewtonsoftJson (#64)

Bumps [Microsoft.AspNetCore.Mvc.NewtonsoftJson](https://github.com/dotnet/aspnetcore) from 6.0.6 to 6.0.7.
- [Release notes](https://github.com/dotnet/aspnetcore/releases)
- [Changelog](https://github.com/dotnet/aspnetcore/blob/main/docs/ReleasePlanning.md)
- [Commits](https://github.com/dotnet/aspnetcore/compare/v6.0.6...v6.0.7)

---
updated-dependencies:
- dependency-name: Microsoft.AspNetCore.Mvc.NewtonsoftJson dependency-type: direct:production update-type: version-update:semver-patch ...





* chore(deps): bump Microsoft.Extensions.Http.Polly from 6.0.6 to 6.0.7 (#65)

Bumps [Microsoft.Extensions.Http.Polly](https://github.com/dotnet/aspnetcore) from 6.0.6 to 6.0.7.
- [Release notes](https://github.com/dotnet/aspnetcore/releases)
- [Changelog](https://github.com/dotnet/aspnetcore/blob/main/docs/ReleasePlanning.md)
- [Commits](https://github.com/dotnet/aspnetcore/compare/v6.0.6...v6.0.7)

---
updated-dependencies:
- dependency-name: Microsoft.Extensions.Http.Polly dependency-type: direct:production update-type: version-update:semver-patch ...





* chore(deps): bump Trakx.Utils from 0.6.7 to 0.6.10 (#66)

Bumps Trakx.Utils from 0.6.7 to 0.6.10.

---
updated-dependencies:
- dependency-name: Trakx.Utils dependency-type: direct:production update-type: version-update:semver-patch ...





* chore(deps): bump xunit from 2.4.1 to 2.4.2 (#68)

Bumps [xunit](https://github.com/xunit/xunit) from 2.4.1 to 2.4.2.
- [Release notes](https://github.com/xunit/xunit/releases)
- [Commits](https://github.com/xunit/xunit/compare/2.4.1...2.4.2)

---
updated-dependencies:
- dependency-name: xunit dependency-type: direct:production update-type: version-update:semver-patch ...





* chore(deps): bump Trakx.Utils.Testing from 0.6.9 to 0.6.10 (#67)

Bumps Trakx.Utils.Testing from 0.6.9 to 0.6.10.

---
updated-dependencies:
- dependency-name: Trakx.Utils.Testing dependency-type: direct:production update-type: version-update:semver-patch ...





* chore(deps): bump Microsoft.AspNetCore.Mvc.NewtonsoftJson (#69)

Bumps [Microsoft.AspNetCore.Mvc.NewtonsoftJson](https://github.com/dotnet/aspnetcore) from 6.0.7 to 6.0.8.
- [Release notes](https://github.com/dotnet/aspnetcore/releases)
- [Changelog](https://github.com/dotnet/aspnetcore/blob/main/docs/ReleasePlanning.md)
- [Commits](https://github.com/dotnet/aspnetcore/compare/v6.0.7...v6.0.8)

---
updated-dependencies:
- dependency-name: Microsoft.AspNetCore.Mvc.NewtonsoftJson dependency-type: direct:production update-type: version-update:semver-patch ...





* chore(deps): bump Microsoft.Extensions.Http.Polly from 6.0.7 to 6.0.8 (#70)

Bumps [Microsoft.Extensions.Http.Polly](https://github.com/dotnet/aspnetcore) from 6.0.7 to 6.0.8.
- [Release notes](https://github.com/dotnet/aspnetcore/releases)
- [Changelog](https://github.com/dotnet/aspnetcore/blob/main/docs/ReleasePlanning.md)
- [Commits](https://github.com/dotnet/aspnetcore/compare/v6.0.7...v6.0.8)

---
updated-dependencies:
- dependency-name: Microsoft.Extensions.Http.Polly dependency-type: direct:production update-type: version-update:semver-patch ...





* chore(deps): bump Microsoft.NET.Test.Sdk from 17.2.0 to 17.3.0 (#71)

Bumps [Microsoft.NET.Test.Sdk](https://github.com/microsoft/vstest) from 17.2.0 to 17.3.0.
- [Release notes](https://github.com/microsoft/vstest/releases)
- [Commits](https://github.com/microsoft/vstest/compare/v17.2.0...v17.3.0)

---
updated-dependencies:
- dependency-name: Microsoft.NET.Test.Sdk dependency-type: direct:production update-type: version-update:semver-minor ...






* chore(deps): bump Trakx.Utils from 0.6.10 to 0.6.11 (#72)

Bumps Trakx.Utils from 0.6.10 to 0.6.11.

---
updated-dependencies:
- dependency-name: Trakx.Utils dependency-type: direct:production update-type: version-update:semver-patch ...






* chore(deps): bump Trakx.Utils.Testing from 0.6.10 to 0.6.11 (#73)

Bumps Trakx.Utils.Testing from 0.6.10 to 0.6.11.

---
updated-dependencies:
- dependency-name: Trakx.Utils.Testing dependency-type: direct:production update-type: version-update:semver-patch ...






* chore(deps): bump Trakx.Utils.Testing from 0.6.11 to 0.6.12 (#75)

Bumps Trakx.Utils.Testing from 0.6.11 to 0.6.12.

---
updated-dependencies:
- dependency-name: Trakx.Utils.Testing dependency-type: direct:production update-type: version-update:semver-patch ...






* chore(deps): bump Trakx.Utils from 0.6.11 to 0.6.12 (#74)

Bumps Trakx.Utils from 0.6.11 to 0.6.12.

---
updated-dependencies:
- dependency-name: Trakx.Utils dependency-type: direct:production update-type: version-update:semver-patch ...






* chore(deps): bump Microsoft.NET.Test.Sdk from 17.3.0 to 17.3.1 (#76)

Bumps [Microsoft.NET.Test.Sdk](https://github.com/microsoft/vstest) from 17.3.0 to 17.3.1.
- [Release notes](https://github.com/microsoft/vstest/releases)
- [Commits](https://github.com/microsoft/vstest/compare/v17.3.0...v17.3.1)

---
updated-dependencies:
- dependency-name: Microsoft.NET.Test.Sdk dependency-type: direct:production update-type: version-update:semver-patch ...






* chore(deps): bump Serilog from 2.11.0 to 2.12.0 (#77)

Bumps [Serilog](https://github.com/serilog/serilog) from 2.11.0 to 2.12.0.
- [Release notes](https://github.com/serilog/serilog/releases)
- [Changelog](https://github.com/serilog/serilog/blob/dev/CHANGES.md)
- [Commits](https://github.com/serilog/serilog/compare/v2.11.0...v2.12.0)

---
updated-dependencies:
- dependency-name: Serilog dependency-type: direct:production update-type: version-update:semver-minor ...






* chore(deps): bump Microsoft.Extensions.Http.Polly from 6.0.8 to 6.0.9 (#78)

Bumps [Microsoft.Extensions.Http.Polly](https://github.com/dotnet/aspnetcore) from 6.0.8 to 6.0.9.
- [Release notes](https://github.com/dotnet/aspnetcore/releases)
- [Changelog](https://github.com/dotnet/aspnetcore/blob/main/docs/ReleasePlanning.md)
- [Commits](https://github.com/dotnet/aspnetcore/compare/v6.0.8...v6.0.9)

---
updated-dependencies:
- dependency-name: Microsoft.Extensions.Http.Polly dependency-type: direct:production update-type: version-update:semver-patch ...






* chore(deps): bump Microsoft.AspNetCore.Mvc.NewtonsoftJson (#79)

Bumps [Microsoft.AspNetCore.Mvc.NewtonsoftJson](https://github.com/dotnet/aspnetcore) from 6.0.8 to 6.0.9.
- [Release notes](https://github.com/dotnet/aspnetcore/releases)
- [Changelog](https://github.com/dotnet/aspnetcore/blob/main/docs/ReleasePlanning.md)
- [Commits](https://github.com/dotnet/aspnetcore/compare/v6.0.8...v6.0.9)

---
updated-dependencies:
- dependency-name: Microsoft.AspNetCore.Mvc.NewtonsoftJson dependency-type: direct:production update-type: version-update:semver-patch ...






* chore(deps): bump NSwag.MSBuild from 13.16.1 to 13.17.0 (#80)

Bumps [NSwag.MSBuild](https://github.com/RicoSuter/NSwag) from 13.16.1 to 13.17.0.
- [Release notes](https://github.com/RicoSuter/NSwag/releases)
- [Changelog](https://github.com/RicoSuter/NSwag/blob/master/CHANGELOG.md)
- [Commits](https://github.com/RicoSuter/NSwag/compare/v13.16.1...v13.17.0)

---
updated-dependencies:
- dependency-name: NSwag.MSBuild dependency-type: direct:production update-type: version-update:semver-minor ...






* chore(deps): bump Microsoft.NET.Test.Sdk from 17.3.1 to 17.3.2 (#81)

Bumps [Microsoft.NET.Test.Sdk](https://github.com/microsoft/vstest) from 17.3.1 to 17.3.2.
- [Release notes](https://github.com/microsoft/vstest/releases)
- [Commits](https://github.com/microsoft/vstest/compare/v17.3.1...v17.3.2)

---
updated-dependencies:
- dependency-name: Microsoft.NET.Test.Sdk dependency-type: direct:production update-type: version-update:semver-patch ...






* chore(deps): bump Microsoft.AspNetCore.Mvc.NewtonsoftJson (#82)

Bumps [Microsoft.AspNetCore.Mvc.NewtonsoftJson](https://github.com/dotnet/aspnetcore) from 6.0.9 to 6.0.10.
- [Release notes](https://github.com/dotnet/aspnetcore/releases)
- [Changelog](https://github.com/dotnet/aspnetcore/blob/main/docs/ReleasePlanning.md)
- [Commits](https://github.com/dotnet/aspnetcore/compare/v6.0.9...v6.0.10)

---
updated-dependencies:
- dependency-name: Microsoft.AspNetCore.Mvc.NewtonsoftJson dependency-type: direct:production update-type: version-update:semver-patch ...






* chore(deps): bump Microsoft.Extensions.DependencyInjection (#83)

Bumps [Microsoft.Extensions.DependencyInjection](https://github.com/dotnet/runtime) from 6.0.0 to 6.0.1.
- [Release notes](https://github.com/dotnet/runtime/releases)
- [Commits](https://github.com/dotnet/runtime/compare/v6.0.0...v6.0.1)

---
updated-dependencies:
- dependency-name: Microsoft.Extensions.DependencyInjection dependency-type: direct:production update-type: version-update:semver-patch ...






* chore(deps): bump Microsoft.Extensions.Http.Polly from 6.0.9 to 6.0.10 (#84)

Bumps [Microsoft.Extensions.Http.Polly](https://github.com/dotnet/aspnetcore) from 6.0.9 to 6.0.10.
- [Release notes](https://github.com/dotnet/aspnetcore/releases)
- [Changelog](https://github.com/dotnet/aspnetcore/blob/main/docs/ReleasePlanning.md)
- [Commits](https://github.com/dotnet/aspnetcore/compare/v6.0.9...v6.0.10)

---
updated-dependencies:
- dependency-name: Microsoft.Extensions.Http.Polly dependency-type: direct:production update-type: version-update:semver-patch ...






* chore(deps): bump FluentAssertions from 6.7.0 to 6.8.0 (#85)

Bumps [FluentAssertions](https://github.com/fluentassertions/fluentassertions) from 6.7.0 to 6.8.0.
- [Release notes](https://github.com/fluentassertions/fluentassertions/releases)
- [Changelog](https://github.com/fluentassertions/fluentassertions/blob/develop/AcceptApiChanges.ps1)
- [Commits](https://github.com/fluentassertions/fluentassertions/compare/6.7.0...6.8.0)

---
updated-dependencies:
- dependency-name: FluentAssertions dependency-type: direct:production update-type: version-update:semver-minor ...






* remove exchanges that we dont trust from supported exchanges (#86)

* remove old projects that make the build fail 🤒💩

* Change case of new exchanges, add a test to list them as they are getting serialised in Enum Values

* chore(deps): bump coverlet.collector from 3.1.2 to 3.2.0 (#90)

Bumps [coverlet.collector](https://github.com/coverlet-coverage/coverlet) from 3.1.2 to 3.2.0.
- [Release notes](https://github.com/coverlet-coverage/coverlet/releases)
- [Commits](https://github.com/coverlet-coverage/coverlet/commits/v3.2.0)

---
updated-dependencies:
- dependency-name: coverlet.collector dependency-type: direct:production update-type: version-update:semver-minor ...






* chore(deps): bump coverlet.msbuild from 3.1.2 to 3.2.0 (#91)

Bumps [coverlet.msbuild](https://github.com/coverlet-coverage/coverlet) from 3.1.2 to 3.2.0.
- [Release notes](https://github.com/coverlet-coverage/coverlet/releases)
- [Commits](https://github.com/coverlet-coverage/coverlet/commits/v3.2.0)

---
updated-dependencies:
- dependency-name: coverlet.msbuild dependency-type: direct:production update-type: version-update:semver-minor ...







* Trying to change the minimum to fix the issue longer term (#111)

* chore(deps): bump actions/delete-package-versions from 3 to 4 (#107)

Bumps [actions/delete-package-versions](https://github.com/actions/delete-package-versions) from 3 to 4.
- [Release notes](https://github.com/actions/delete-package-versions/releases)
- [Commits](https://github.com/actions/delete-package-versions/compare/v3...v4)

---
updated-dependencies:
- dependency-name: actions/delete-package-versions dependency-type: direct:production update-type: version-update:semver-major ...





* update copyright year (#113)

* update copyright year

* fix copyright year

---------